### PR TITLE
Fix a bug in DrawerView

### DIFF
--- a/src/views/DrawerView.js
+++ b/src/views/DrawerView.js
@@ -24,10 +24,10 @@ export default class DrawerView extends React.PureComponent {
     const { isDrawerOpen } = this.props.navigation.state;
     const wasDrawerOpen = prevProps.navigation.state.isDrawerOpen;
 
-    if (isDrawerOpen && !wasDrawerOpen && this._drawerState === 'closed') {
+    if (this._shouldOpen(isDrawerOpen, wasDrawerOpen)) {
       this._drawerState = 'opening';
       this._drawer.openDrawer();
-    } else if (wasDrawerOpen && !isDrawerOpen && this._drawerState === 'open') {
+    } else if (this._shouldClose(isDrawerOpen, wasDrawerOpen)) {
       this._drawerState = 'closing';
       this._drawer.closeDrawer();
     }
@@ -38,6 +38,22 @@ export default class DrawerView extends React.PureComponent {
   }
 
   _drawerState = 'closed';
+
+  _shouldOpen = (isDrawerOpen, wasDrawerOpen) => {
+    return (
+      isDrawerOpen &&
+      !wasDrawerOpen &&
+      (this._drawerState === 'closed' || this._drawerState === 'closing')
+    );
+  };
+
+  _shouldClose = (isDrawerOpen, wasDrawerOpen) => {
+    return (
+      wasDrawerOpen &&
+      !isDrawerOpen &&
+      (this._drawerState === 'open' || this._drawerState === 'opening')
+    );
+  };
 
   _handleDrawerOpen = () => {
     const { navigation } = this.props;


### PR DESCRIPTION
When attempting to navigate to a drawer item while the drawer's state
is 'opening' or 'closing' results in a state where the underlying navigator's
screen correctly changes but the drawer fails to automatically dismiss itself.

Instead, we should allow the drawer to respond to updates and change it's state
even if it's in the middle of 'opening' or 'closing'.

Related issue: https://github.com/react-navigation/react-navigation/issues/4444
This is a reproduction of the fix in https://github.com/react-navigation/react-navigation/pull/4443