### PR TITLE
Fix back handling in Drawer Router

### DIFF
--- a/src/routers/DrawerRouter.js
+++ b/src/routers/DrawerRouter.js
@@ -1,4 +1,4 @@
-import { SwitchRouter } from 'react-navigation';
+import { SwitchRouter, NavigationActions } from 'react-navigation';
 import DrawerActions from './DrawerActions';
 
 function withDefaultValue(obj, key, defaultValue) {
@@ -68,6 +68,13 @@ export default (routeConfigs, config = {}) => {
         }
 
         if (action.type === DrawerActions.CLOSE_DRAWER) {
+          return {
+            ...state,
+            closeId: state.closeId + 1,
+          };
+        }
+
+        if (action.type === NavigationActions.BACK && state.isDrawerOpen) {
           return {
             ...state,
             closeId: state.closeId + 1,


### PR DESCRIPTION
As reported in https://github.com/react-navigation/react-navigation/issues/4768, the android back button does not seem to behave for the drawer when inside of a stack.
