### PR TITLE
Expose styling for drawer container

### DIFF
--- a/src/views/DrawerLayout.js
+++ b/src/views/DrawerLayout.js
@@ -54,6 +54,7 @@ export type PropType = {
   hideStatusBar?: boolean,
   statusBarAnimation?: 'slide' | 'none' | 'fade',
   overlayColor: string,
+  drawerContainerStyle?: any,
   contentContainerStyle?: any,
 
   // Added in this fork, needs to be upstreamed
@@ -369,6 +370,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
       drawerWidth,
       drawerPosition,
       drawerType,
+      drawerContainerStyle,
       contentContainerStyle,
     } = this.props;
 
@@ -431,7 +433,7 @@ export default class DrawerLayout extends Component<PropType, StateType> {
         <Animated.View
           pointerEvents="box-none"
           accessibilityViewIsModal={drawerShown}
-          style={[styles.drawerContainer, drawerStyles]}>
+          style={[styles.drawerContainer, drawerStyles, drawerContainerStyle]}>
           <View style={[styles.drawer, dynamicDrawerStyles]}>
             {this.props.renderNavigationView(this._openValue)}
           </View>

--- a/src/views/DrawerView.js
+++ b/src/views/DrawerView.js
@@ -233,6 +233,9 @@ export default class DrawerView extends React.PureComponent {
         statusBarAnimation={this.props.navigationConfig.statusBarAnimation}
         minSwipeDistance={this.props.navigationConfig.minSwipeDistance}
         overlayColor={this.props.navigationConfig.overlayColor}
+        drawerContainerStyle={
+          this.props.navigationConfig.drawerContainerStyle
+        }
         contentContainerStyle={
           this.props.navigationConfig.contentContainerStyle
         }


### PR DESCRIPTION
People have asked for a way to [customize the drawer's overlay opacity](https://react-navigation.canny.io/feature-requests/p/customize-overlay-opacity-for-drawer) and [color](https://github.com/react-navigation/react-navigation/issues/1068).

To cover all their needs and many others not yet represented, I'd like to propose exposing the container styling of the drawer. This has already been done with the content container styling so I believe this follows the trend.

I've read as much as I could and I couldn't find any arguments as to why this shouldn't be exposed. I'd be interested to hear any feedback and work on adjusting my pull request accordingly.

I'll offer my own usecase here as well. I need to be able to remove the overlay opacity, as well as adjust the position, shadow and border of the drawer container to match a design that I've been provided. Pictured is the result I was able to achieve by exposing the container styles:

![screen shot 2018-12-10 at 4 18 56 pm](https://user-images.githubusercontent.com/1750298/49765807-2a9e1880-fc99-11e8-9ae7-ee7858aa919a.png)

And I see good reason for this design, since I want to make the list of results under my drawer visible as a user updates their filters inside the drawer. I also want to vertically align the drawer with the button that opens it (not pictured, displayed under the drawer).

Again, I'm open to feedback and any advice on how to proceed. It's my first time submitting a pull request for a major project. Thank you! :)
