### PR TITLE
feat: Move itemStyle to SafeAreaView 

### DIFF
--- a/src/views/DrawerNavigatorItems.js
+++ b/src/views/DrawerNavigatorItems.js
@@ -47,35 +47,33 @@ const DrawerNavigatorItems = ({
           delayPressIn={0}
         >
           <SafeAreaView
-            style={{ backgroundColor }}
+            style={[{ backgroundColor }, styles.item, itemStyle]}
             forceInset={{
               [drawerPosition]: 'always',
               [drawerPosition === 'left' ? 'right' : 'left']: 'never',
               vertical: 'never',
             }}
           >
-            <View style={[styles.item, itemStyle]}>
-              {icon ? (
-                <View
-                  style={[
-                    styles.icon,
-                    focused ? null : styles.inactiveIcon,
-                    iconContainerStyle,
-                  ]}
-                >
-                  {icon}
-                </View>
-              ) : null}
-              {typeof label === 'string' ? (
-                <Text
-                  style={[styles.label, { color }, labelStyle, extraLabelStyle]}
-                >
-                  {label}
-                </Text>
-              ) : (
-                label
-              )}
-            </View>
+            {icon ? (
+              <View
+                style={[
+                  styles.icon,
+                  focused ? null : styles.inactiveIcon,
+                  iconContainerStyle,
+                ]}
+              >
+                {icon}
+              </View>
+            ) : null}
+            {typeof label === 'string' ? (
+              <Text
+                style={[styles.label, { color }, labelStyle, extraLabelStyle]}
+              >
+                {label}
+              </Text>
+            ) : (
+              label
+            )}
           </SafeAreaView>
         </TouchableItem>
       );


### PR DESCRIPTION
In order to add a custom style like borderRadius to the drawer item, it's necessary to pass a prop to SafeAreaView. Thus, the inner view was removed and itemStyle has been moved to SafeAreaView.

Before:
![whatsapp image 2019-03-04 at 16 19 34](https://user-images.githubusercontent.com/6487206/53757153-b17a2000-3e99-11e9-965d-244eceb76ccd.jpeg)


After:
```
{
    contentOptions: {
      itemsContainerStyle: {
        padding: 0,
        marginHorizontal: 10,
        marginVertical: 4,
      },
      itemStyle: {
        borderRadius: 4,
      },
    },
  },
```
![whatsapp image 2019-03-04 at 16 21 30](https://user-images.githubusercontent.com/6487206/53757189-cf478500-3e99-11e9-9987-268ecd268c9b.jpeg)
